### PR TITLE
Add const to comparator for Min Cost Max Flow

### DIFF
--- a/mcmf_dijkstra.cpp
+++ b/mcmf_dijkstra.cpp
@@ -30,7 +30,7 @@ namespace Mcmf {
   int next[MAXE], from[MAXE], adj[MAXE]; llint cap[MAXE], cost[MAXE];
 
   struct cmpf {
-    bool operator () (int a, int b) {
+    bool operator () (int a, int b) const {
       if (dist[a] != dist[b]) return dist[a] < dist[b];
       return a < b;
     }


### PR DESCRIPTION
Hi,

I am not sure if this is platform-independent or not, but without const, it will not even compile on my side (Ubuntu 19.10 + Clang++/G++ 9.x). In either case, I believe adding a const is a good practice without harm.

Happy Coding!
Thuan


